### PR TITLE
Feature/michel/camera card auto alignment

### DIFF
--- a/Assets/Scripts/Card Management/CardGenerator.cs
+++ b/Assets/Scripts/Card Management/CardGenerator.cs
@@ -27,18 +27,18 @@ namespace Card_Management
         {
             var generatedCards = new List<CardController>();
     
-            var xPos = 0f;
-            var yPos = 0f;
+            var xPos = _cardDimensions.x / 2 + _cardPadding.x;
+            var yPos = -(_cardDimensions.y / 2 + _cardPadding.y);
         
             for (int x = 0; x < _columns; x++)
             {
-                xPos += (_cardDimensions.x) + _cardPadding.x;
-                
                 for (int y = 0; y < _rows; y++)
                 {
                     var newYPos = yPos - (_cardDimensions.y + _cardPadding.y) * y;
                     generatedCards.Add(GenerateCard(xPos, newYPos));
                 }
+                
+                xPos += _cardDimensions.x + _cardPadding.x;
             }
 
             return generatedCards;

--- a/Assets/Scripts/Card Management/GameManager.cs
+++ b/Assets/Scripts/Card Management/GameManager.cs
@@ -6,6 +6,8 @@ namespace Card_Management
     public class GameManager : MonoBehaviour
     {
         private MatchingManager _matchingManager;
+        private Camera _cam;
+        
         public int _rows;
         public int _columns;
         public CardInfoSO cardInfo;
@@ -19,6 +21,37 @@ namespace Card_Management
             
             if (_matchingManager != null)
                 _matchingManager.SetupCards();
+
+            _cam = Camera.main;
+            FitCardLayoutToCameraView(_rows, _columns, cardInfo);
+        }
+
+        private void FitCardLayoutToCameraView(int rows, int columns, CardInfoSO cardInfoSo)
+        {
+            var totalHeight = rows * (cardInfoSo.cardDimensions.y + cardInfoSo.cardPadding.y);
+            var totalWidth = columns * (cardInfoSo.cardDimensions.x + cardInfoSo.cardPadding.x);
+
+            totalWidth += cardInfo.cardPadding.x;
+            totalHeight += cardInfo.cardPadding.y;
+
+            var centrePoint = new Vector3(totalWidth / 2f, -totalHeight / 2f, -1);
+
+            _cam.transform.position = centrePoint;
+            
+            ScaleCameraViewToCardLayout(totalWidth, totalHeight);
+        }
+
+        private void ScaleCameraViewToCardLayout(float totalWidth, float totalHeight)
+        {
+            var cameraHeight = _cam.orthographicSize * 2;
+            var cameraWidth = cameraHeight * _cam.aspect;
+
+            var layoutWidthRatio = totalWidth / cameraWidth;
+            var layoutHeightRatio = totalHeight / cameraHeight;
+            
+            _cam.orthographicSize = layoutWidthRatio < layoutHeightRatio ? 
+                totalHeight / 2 : 
+                totalWidth / 2 / _cam.aspect;
         }
     }
 }


### PR DESCRIPTION
- Fixed an issue where the initial generation of a card did not incorporate padding or positional offset from the border (0,0)
- Added two methods that repositions the camera to the centre of the screen and sets the othagraphic size to fit the card layout based on its total size and ratio