### PR TITLE
Bug fix for incorrect fps display on android devices

### DIFF
--- a/Assets/Scripts/UI/MainMenuManager.cs
+++ b/Assets/Scripts/UI/MainMenuManager.cs
@@ -53,7 +53,8 @@ public class MainMenuManager : MonoBehaviour
     {
         continueButton.interactable = PlayerDataSerializer.PlayerHasData();
         QualitySettings.vSyncCount = 0;
-        FpsText.text = $"{Application.targetFrameRate} FPS";
+        if (Application.targetFrameRate == -1)
+            ToggleFPS();
         UpdateFPSText();
     }
 
@@ -106,7 +107,7 @@ public class MainMenuManager : MonoBehaviour
 
     public void ToggleFPS()
     {
-        Application.targetFrameRate = Application.targetFrameRate == 60 ? 30 : 60;
+        Application.targetFrameRate = Application.targetFrameRate == 30 ? 60 : 30;
         UpdateFPSText();
     }
     


### PR DESCRIPTION
Added a check in awake if application framerate is -1 to set the targetframe rate. this is an issue that affects android.
Also inverted the target framerate check so we default to 30 if its anything that is not 30